### PR TITLE
fanotify_init.2: Document FAN_EVENT_INFO_TID

### DIFF
--- a/man2/fanotify_init.2
+++ b/man2/fanotify_init.2
@@ -142,6 +142,9 @@ Remove the limit of 8192 marks.
 Use of this flag requires the
 .B CAP_SYS_ADMIN
 capability.
+.TP
+.B FAN_EVENT_INFO_TID
+reporting thread id instead of process id(tgid)
 .PP
 The
 .I event_f_flags

--- a/man7/fanotify.7
+++ b/man7/fanotify.7
@@ -223,7 +223,13 @@ Hence, when the receiver of the fanotify event accesses the notified file or
 directory using this file descriptor, no additional events will be created.
 .TP
 .I pid
-This is the ID of the process that caused the event.
+if flags
+.B FAN_EVENT_INFO_TID
+is set by
+.BR fanotify_init (2),
+This is ID(pid) of the thread that caused the event.
+otherwise This is ID(tgid) of the process that caused the event.
+.PP
 A program listening to fanotify events can compare this PID
 to the PID returned by
 .BR getpid (2),


### PR DESCRIPTION
fanotify_init add new flags FAN_EVENT_INFO_TID
In order to identify which thread triggered the event in a
multi-threaded program, add the FAN_EVENT_INFO_TID flag in fanotify_init
to opt-in for reporting the event creator's thread id information.

Signed-off-by: nixiaoming <nixiaoming@huawei.com>